### PR TITLE
feature: course page recommendation cards

### DIFF
--- a/app/(pages)/[subj]/[id]/page.js
+++ b/app/(pages)/[subj]/[id]/page.js
@@ -3,6 +3,7 @@ import NavigationSearchSmall from "../../../components/search/NavigationSearchSm
 import Link from "next/link";
 
 import Graph from "../../../components/graph/Graph";
+import { Deck } from "../../../components/deck/Deck";
 
 import "../../../components/styles/Idpage.css";
 import "../../../components/styles/Layout.css";
@@ -25,6 +26,8 @@ export default function Page({ params }) {
   if (!Access(SUBJ).ids.includes(ID)) notFound();
 
   let course = Access(SUBJ).getCourse(ID, "id");
+  // this will only display targets from within its subject, but subject-specific accessors will be refactored out soon
+  let targets = Access(SUBJ).target(course);
   let build = {
     includes: [course],
     simplify: false, // set true to remove or/and distinction
@@ -32,7 +35,7 @@ export default function Page({ params }) {
   };
 
   return (
-    <div id="content">
+    <div id="content" className="flex flex-col gap-4">
       <div>
         <Link href={"/" + SUBJ}>
           <button id="back">
@@ -63,6 +66,7 @@ export default function Page({ params }) {
           <p id="info">{course.info}</p>
         </div>
       </div>
+      <Deck courses={targets} />
     </div>
   );
 }

--- a/app/components/deck/Deck.tsx
+++ b/app/components/deck/Deck.tsx
@@ -1,0 +1,33 @@
+// scrolling deck of recommendation cards i.e. courses to take after another
+
+import { Course } from "../../data/types";
+import Link from "next/link";
+
+export { Deck, Card };
+
+function Deck({ courses }: { courses: readonly Course[] }) {
+  return (
+    <div className="container mx-auto pb-4 overflow-x-auto flex flex-row space-x-4 whitespace-nowrap">
+      {courses.map((course, i) => (
+        <Card key={i} course={course} />
+      ))}
+    </div>
+  );
+}
+
+function Card({ course }: { course: Course }) {
+  return (
+    <div className="w-[300px] min-w-[300px] bg-white shadow-lg text-black p-4 rounded-md">
+      <div className="basis-1/6 font-medium text-lg rounded-lg">
+        <h2>{course.code}</h2>
+      </div>
+      <div className="basis-full pb-2 font-normal text-base line-clamp-1 overflow-hidden text-ellipsis">
+        {/* TODO use long name instead of short name */}
+        <h3>{course.title}</h3>
+      </div>
+      <div className="font-light text-sm h-20 line-clamp-4 text-wrap overflow-hidden text-ellipsis">
+        <p>{course.info}</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
course page now has horizontal container with course cards that you can take after the current page's course (i.e. "targets" of the current page course are displayed at the bottom of the page as recommendations)

the components are logic-agnostic, so we can switch to a more sophisticated recommendation algorithm later to also suggest related courses and not just "target" courses

this should also be tweaked once the new data is in use so it displays full names instead of short names
(I also didn't add any kind of link where you should be able to click on the card to go to that course's page)